### PR TITLE
ServiceRepository implementation based on Consul

### DIFF
--- a/consul/consul.go
+++ b/consul/consul.go
@@ -22,20 +22,20 @@ func NewServiceRepository(consulAgent consulAgent) *ServiceRepository {
 }
 
 // Register adds service into consul
-func (c *ServiceRepository) Register(service *registry.Service) error {
-	return c.consulAgent.ServiceRegister(
+func (r *ServiceRepository) Register(service *registry.Service) error {
+	return r.consulAgent.ServiceRegister(
 		buildAgentServiceRegistration(service),
 	)
 }
 
 // Deregister removes service from consul
-func (c *ServiceRepository) Deregister(serviceID string) error {
-	return c.consulAgent.ServiceDeregister(serviceID)
+func (r *ServiceRepository) Deregister(serviceID string) error {
+	return r.consulAgent.ServiceDeregister(serviceID)
 }
 
 // GetAllIds return array of services ids registered in consul
-func (c *ServiceRepository) GetAllIds() []string {
-	services, _ := c.consulAgent.Services()
+func (r *ServiceRepository) GetAllIds() []string {
+	services, _ := r.consulAgent.Services()
 	servicesIDs := []string{}
 	for _, service := range services {
 		servicesIDs = append(servicesIDs, service.ID)

--- a/consul/consul.go
+++ b/consul/consul.go
@@ -28,8 +28,8 @@ func (c *ServiceRepository) Register(service *registry.Service) error {
 	)
 }
 
-// Unregister removes service from consul
-func (c *ServiceRepository) Unregister(serviceID string) error {
+// Deregister removes service from consul
+func (c *ServiceRepository) Deregister(serviceID string) error {
 	return c.consulAgent.ServiceDeregister(serviceID)
 }
 

--- a/consul/consul.go
+++ b/consul/consul.go
@@ -24,7 +24,7 @@ func NewServiceRepository(consulAgent consulAgent) *ServiceRepository {
 // Register adds service into consul
 func (c *ServiceRepository) Register(service *registry.Service) error {
 	return c.consulAgent.ServiceRegister(
-		c.serviceToAgentServiceRegistration(service),
+		buildAgentServiceRegistration(service),
 	)
 }
 
@@ -43,7 +43,7 @@ func (c *ServiceRepository) GetAllIds() []string {
 	return servicesIDs
 }
 
-func (c *ServiceRepository) serviceToAgentServiceRegistration(service *registry.Service) *consul.AgentServiceRegistration {
+func buildAgentServiceRegistration(service *registry.Service) *consul.AgentServiceRegistration {
 	return &consul.AgentServiceRegistration{
 		ID:   service.ID,
 		Name: service.Service,

--- a/consul/consul.go
+++ b/consul/consul.go
@@ -1,97 +1,52 @@
 package consul
 
 import (
+	"github.com/alaa/pencil-go/registry"
 	consul "github.com/hashicorp/consul/api"
 )
 
-type ConsulClient struct {
-	client *consul.Client
+// ServiceRepository is consul-based implementation of registry.ServiceRepository
+type ServiceRepository struct {
+	consulAgent consulAgent
 }
 
-func NewConsulClient() (ConsulClient, error) {
-	client, err := consul.NewClient(consul.DefaultConfig())
-	if err != nil {
-		return ConsulClient{}, err
+type consulAgent interface {
+	Services() (map[string]*consul.AgentService, error)
+	ServiceRegister(service *consul.AgentServiceRegistration) error
+	ServiceDeregister(serviceID string) error
+}
+
+// NewServiceRepository creates new instance of ServiceRepository structure
+func NewServiceRepository(consulAgent consulAgent) *ServiceRepository {
+	return &ServiceRepository{consulAgent}
+}
+
+// Register adds service into consul
+func (c *ServiceRepository) Register(service *registry.Service) error {
+	return c.consulAgent.ServiceRegister(
+		c.serviceToAgentServiceRegistration(service),
+	)
+}
+
+// Unregister removes service from consul
+func (c *ServiceRepository) Unregister(serviceID string) error {
+	return c.consulAgent.ServiceDeregister(serviceID)
+}
+
+// GetAllIds return array of services ids registered in consul
+func (c *ServiceRepository) GetAllIds() []string {
+	services, _ := c.consulAgent.Services()
+	servicesIDs := []string{}
+	for _, service := range services {
+		servicesIDs = append(servicesIDs, service.ID)
 	}
-	return ConsulClient{client: client}, nil
+	return servicesIDs
 }
 
-type ConsulAgent struct {
-	agent *consul.Agent
-}
-
-func (c *ConsulClient) NewConsulAgent() ConsulAgent {
-	agent := c.client.Agent()
-	return ConsulAgent{agent: agent}
-}
-
-type Member struct {
-	Name string
-	IP   string
-	Port uint16
-}
-
-type Members []Member
-
-func buildMember(name string, ip string, port uint16) Member {
-	return Member{Name: name, IP: ip, Port: port}
-}
-
-func (a *ConsulAgent) members() Members {
-	list := Members{}
-	use_wan := false
-	members, _ := a.agent.Members(use_wan)
-	for _, member := range members {
-		list = append(list, buildMember(member.Name, member.Addr, member.Port))
+func (c *ServiceRepository) serviceToAgentServiceRegistration(service *registry.Service) *consul.AgentServiceRegistration {
+	return &consul.AgentServiceRegistration{
+		ID:   service.ID,
+		Name: service.Service,
+		Port: service.Port,
 	}
-	return list
-}
-
-func buildService(id string, name string, port int, ip string) consul.AgentServiceRegistration {
-	return consul.AgentServiceRegistration{ID: id, Name: name, Port: port, Address: ip}
-}
-
-func (a *ConsulAgent) Services() (map[string]*consul.AgentService, error) {
-	services, err := a.agent.Services()
-	if err != nil {
-		return services, err
-	}
-	return services, nil
-}
-
-func (a *ConsulAgent) ServicesIDs() ([]string, error) {
-	services, err := a.agent.Services()
-	if err != nil {
-		return []string{""}, err
-	}
-
-	list := []string{}
-	for _, srv := range services {
-		list = append(list, srv.ID)
-	}
-
-	return list, nil
-}
-
-func (a *ConsulAgent) RegisterService(id string, name string, port int, ip string) error {
-	srv := buildService(id, name, port, ip)
-	if err := a.agent.ServiceRegister(&srv); err != nil {
-		return err
-	}
-	return nil
-}
-
-func (a *ConsulAgent) DeregisterService(id string) error {
-	if err := a.agent.ServiceDeregister(id); err != nil {
-		return err
-	}
-	return nil
-}
-
-func (a *ConsulAgent) DeregisterAllServices() error {
-	services, _ := a.Services()
-	for service := range services {
-		a.DeregisterService(service)
-	}
-	return nil
 }

--- a/consul/consul_test.go
+++ b/consul/consul_test.go
@@ -1,0 +1,87 @@
+package consul
+
+import (
+	"github.com/alaa/pencil-go/registry"
+	consul "github.com/hashicorp/consul/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"sort"
+	"testing"
+)
+
+func TestThatRegisterCallConsulApiRegister(t *testing.T) {
+	consulAgent := new(MockConsulAgent)
+	consulServiceRepository := NewServiceRepository(consulAgent)
+
+	consulAgent.On("ServiceRegister", &consul.AgentServiceRegistration{
+		ID:   "redis1",
+		Name: "redis",
+		Port: 8000,
+	}).Return(nil)
+
+	err := consulServiceRepository.Register(&registry.Service{
+		ID:      "redis1",
+		Service: "redis",
+		Port:    8000,
+	})
+
+	assert.Nil(t, err)
+	consulAgent.AssertExpectations(t)
+}
+
+func TestThatUnregisterCallConsulApiDeregister(t *testing.T) {
+	consulAgent := new(MockConsulAgent)
+	consulServiceRepository := NewServiceRepository(consulAgent)
+
+	consulAgent.On("ServiceDeregister", "redis1").Return(nil)
+
+	err := consulServiceRepository.Unregister("redis1")
+	assert.Nil(t, err)
+	consulAgent.AssertExpectations(t)
+}
+
+type MockConsulAgent struct {
+	mock.Mock
+}
+
+func TestThatGetAllIdsReturnArrayOfServicesIds(t *testing.T) {
+	consulAgent := new(MockConsulAgent)
+	consulServiceRepository := NewServiceRepository(consulAgent)
+
+	consulAgent.On("Services").Return(map[string]*consul.AgentService{
+		"redis": &consul.AgentService{
+			ID:      "redis",
+			Service: "redis",
+			Address: "",
+			Port:    8000,
+		},
+		"memcached": &consul.AgentService{
+			ID:      "memcached",
+			Service: "memcached",
+			Address: "",
+			Port:    9000,
+		},
+	}, nil)
+
+	expectedArrayIds := []string{"memcached", "redis"}
+	servicesIds := consulServiceRepository.GetAllIds()
+	sort.Strings(servicesIds)
+	assert.Equal(t, expectedArrayIds, servicesIds)
+
+	consulAgent.AssertExpectations(t)
+}
+
+func (mca *MockConsulAgent) Services() (map[string]*consul.AgentService, error) {
+	args := mca.Called()
+	return args.Get(0).(map[string]*consul.AgentService), args.Error(1)
+}
+
+func (mca *MockConsulAgent) ServiceRegister(service *consul.AgentServiceRegistration) error {
+	args := mca.Called(service)
+	return args.Error(0)
+}
+
+func (mca *MockConsulAgent) ServiceDeregister(serviceID string) error {
+	args := mca.Called(serviceID)
+	return args.Error(0)
+}

--- a/consul/consul_test.go
+++ b/consul/consul_test.go
@@ -29,13 +29,13 @@ func TestThatRegisterCallConsulApiRegister(t *testing.T) {
 	consulAgent.AssertExpectations(t)
 }
 
-func TestThatUnregisterCallConsulApiDeregister(t *testing.T) {
+func TestThatDeregisterCallConsulApiDeregister(t *testing.T) {
 	consulAgent := new(MockConsulAgent)
 	consulServiceRepository := NewServiceRepository(consulAgent)
 
 	consulAgent.On("ServiceDeregister", "redis1").Return(nil)
 
-	err := consulServiceRepository.Unregister("redis1")
+	err := consulServiceRepository.Deregister("redis1")
 	assert.Nil(t, err)
 	consulAgent.AssertExpectations(t)
 }

--- a/main.go
+++ b/main.go
@@ -2,22 +2,34 @@ package main
 
 import (
 	"fmt"
-	//consul "github.com/alaa/pencil-go/consul"
+	"github.com/alaa/pencil-go/consul"
 	"github.com/alaa/pencil-go/docker"
 	dockerclient "github.com/fsouza/go-dockerclient"
+	consulclient "github.com/hashicorp/consul/api"
 	"time"
 )
 
 func main() {
 	fmt.Println("starting pencil ...\n")
-	client, _ := dockerclient.NewClient(docker.Endpoint)
-	adapter := docker.NewDockerAdapter(client)
+
+	dockerAdapter := getDockerAdapter()
+
 	c := time.Tick(docker.Interval)
 	for range c {
-		containers, _ := adapter.GetRunningContainers()
+		containers, _ := dockerAdapter.GetRunningContainers()
 		fmt.Printf("containers: %v\n", containers)
 		for _, container := range containers {
 			fmt.Printf("%s %s %s service_name:%s \n\n", container.ID, container.ImageName, container.TCPPorts, container.ServiceName)
 		}
 	}
+}
+
+func getDockerAdapter() *docker.DockerAdapter {
+	client, _ := dockerclient.NewClient(docker.Endpoint)
+	return docker.NewDockerAdapter(client)
+}
+
+func getConsulAdapter() *consul.ServiceRepository {
+	consulClient, _ := consulclient.NewClient(consulclient.DefaultConfig())
+	return consul.NewServiceRepository(consulClient.Agent())
 }

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -30,8 +30,8 @@ func (r *Registry) registerServices(registeredServicesIDs []string, runningConta
 }
 
 func (r *Registry) unregisterServices(registeredServicesIDs []string, runningContainers []*Container) {
-	for _, serviceID := range r.servicesIDsToUnregister(registeredServicesIDs, runningContainers) {
-		r.serviceRepository.Unregister(serviceID)
+	for _, serviceID := range r.servicesIDsToDeregister(registeredServicesIDs, runningContainers) {
+		r.serviceRepository.Deregister(serviceID)
 	}
 }
 
@@ -46,15 +46,15 @@ func (r *Registry) servicesToRegister(registeredServicesIDs []string, runningCon
 	return servicesToRegister
 }
 
-func (r *Registry) servicesIDsToUnregister(registeredServicesIDs []string, runningContainers []*Container) []string {
-	servicesIdsToUnregister := []string{}
+func (r *Registry) servicesIDsToDeregister(registeredServicesIDs []string, runningContainers []*Container) []string {
+	servicesIdsToDeregister := []string{}
 	runningContainersIDsSet := r.containersIDsMap(runningContainers)
 	for _, serviceID := range registeredServicesIDs {
 		if _, ok := runningContainersIDsSet[serviceID]; !ok {
-			servicesIdsToUnregister = append(servicesIdsToUnregister, serviceID)
+			servicesIdsToDeregister = append(servicesIdsToDeregister, serviceID)
 		}
 	}
-	return servicesIdsToUnregister
+	return servicesIdsToDeregister
 }
 
 func containerToService(container *Container) *Service {

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -106,7 +106,7 @@ func TestSynchronieWhenOneServiceIsMissingAndOneIsRedundant(t *testing.T) {
 		Service: "/naughty_heisenberg",
 		Port:    9000,
 	}).Return(nil)
-	serviceRepository.On("Unregister", "0g1d34c0ebeeb62dfdcc57327aca15d2ef3cbc39a60e44aecb7085a8d1f89fd9").Return(nil)
+	serviceRepository.On("Deregister", "0g1d34c0ebeeb62dfdcc57327aca15d2ef3cbc39a60e44aecb7085a8d1f89fd9").Return(nil)
 
 	registry.Synchronize()
 
@@ -132,7 +132,7 @@ func (msr *MockServiceRepository) Register(service *Service) error {
 	return args.Error(0)
 }
 
-func (msr *MockServiceRepository) Unregister(serviceID string) error {
+func (msr *MockServiceRepository) Deregister(serviceID string) error {
 	args := msr.Called(serviceID)
 	return args.Error(0)
 }

--- a/registry/repositories.go
+++ b/registry/repositories.go
@@ -9,7 +9,7 @@ type ContainerRepository interface {
 type ServiceRepository interface {
 	GetAllIds() []string
 	Register(service *Service) error
-	Unregister(serviceID string) error
+	Deregister(serviceID string) error
 }
 
 // Container entity


### PR DESCRIPTION
- We've created `consul/consul.go` from scratch so I recommend to review whole file instead of diff
- It adds `consul.Adapter` structure which is responsible for synchronizing consul registered services with running docker containers

It works together with `docker.DockerAdapter` as follows:
- `docker.DockerAdapter.getRunningContainers()` method returns list of running containers...
- ...which we pass to `consul.Adapter.Synchronize()` method to update consul registry

`Synchronize` method:
- registers running containers which are not yet registered
- unregisters containers which are no longer running
