### PR TITLE
Registry package draft

### DIFF
--- a/registry/registry.go
+++ b/registry/registry.go
@@ -1,0 +1,78 @@
+package registry
+
+// Registry understands how to synchronize registered Services with running Containers
+type Registry struct {
+	containerRepository ContainerRepository
+	serviceRepository   ServiceRepository
+}
+
+// NewRegistry creates new instance of Registry
+func NewRegistry(containerRepository ContainerRepository, serviceRepository ServiceRepository) *Registry {
+	return &Registry{
+		containerRepository,
+		serviceRepository,
+	}
+}
+
+// Synchronize synchronizes registered services according to running containers
+func (r *Registry) Synchronize() {
+	registeredServicesIDs := r.serviceRepository.GetAllIds()
+	runningContainers := r.containerRepository.GetAll()
+
+	r.registerServices(registeredServicesIDs, runningContainers)
+	r.unregisterServices(registeredServicesIDs, runningContainers)
+}
+
+func (r *Registry) registerServices(registeredServicesIDs []string, runningContainers []*Container) {
+	for _, service := range r.servicesToRegister(registeredServicesIDs, runningContainers) {
+		r.serviceRepository.Register(service)
+	}
+}
+
+func (r *Registry) unregisterServices(registeredServicesIDs []string, runningContainers []*Container) {
+	for _, serviceID := range r.servicesIDsToUnregister(registeredServicesIDs, runningContainers) {
+		r.serviceRepository.Unregister(serviceID)
+	}
+}
+
+func (r *Registry) servicesToRegister(registeredServicesIDs []string, runningContainers []*Container) []*Service {
+	servicesToRegister := []*Service{}
+	registeredServicesIDsMap := r.sliceToMap(registeredServicesIDs)
+	for _, container := range runningContainers {
+		if _, ok := registeredServicesIDsMap[container.ID]; !ok {
+			servicesToRegister = append(servicesToRegister, containerToService(container))
+		}
+	}
+	return servicesToRegister
+}
+
+func (r *Registry) servicesIDsToUnregister(registeredServicesIDs []string, runningContainers []*Container) []string {
+	servicesIdsToUnregister := []string{}
+	runningContainersIDsSet := r.containersIDsMap(runningContainers)
+	for _, serviceID := range registeredServicesIDs {
+		if _, ok := runningContainersIDsSet[serviceID]; !ok {
+			servicesIdsToUnregister = append(servicesIdsToUnregister, serviceID)
+		}
+	}
+	return servicesIdsToUnregister
+}
+
+func containerToService(container *Container) *Service {
+	return &Service{ID: container.ID, Service: container.Name, Port: container.Port}
+}
+
+func (r *Registry) sliceToMap(slice []string) map[string]bool {
+	result := map[string]bool{}
+	for _, item := range slice {
+		result[item] = true
+	}
+	return result
+}
+
+func (r *Registry) containersIDsMap(containers []*Container) map[string]bool {
+	result := map[string]bool{}
+	for _, container := range containers {
+		result[container.ID] = true
+	}
+	return result
+}

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -1,0 +1,143 @@
+package registry
+
+import (
+	"github.com/stretchr/testify/mock"
+	"testing"
+)
+
+func TestSynchronizeWhenNoServicesWereRegisteredBefore(t *testing.T) {
+	serviceRepository := new(MockServiceRepository)
+	containerRepository := new(MockContainerRepository)
+	registry := NewRegistry(containerRepository, serviceRepository)
+
+	serviceRepository.On("GetAllIds").Return([]string{})
+	serviceRepository.On("Register", &Service{
+		ID:      "bd1d34c0ebeeb62dfdcc57327aca15d2ef3cbc39a60e44aecb7085a8d1f89fd9",
+		Service: "/elated_kirch",
+		Port:    22,
+	}).Return(nil)
+	serviceRepository.On("Register", &Service{
+		ID:      "f717f795bcccd674628b92f77a72f4b80b2c6b5da289846a0edbd21fb4c462db",
+		Service: "/naughty_heisenberg",
+		Port:    9000,
+	}).Return(nil)
+
+	containerRepository.On("GetAll").Return(
+		[]*Container{
+			&Container{
+				ID:   "bd1d34c0ebeeb62dfdcc57327aca15d2ef3cbc39a60e44aecb7085a8d1f89fd9",
+				Name: "/elated_kirch",
+				Port: 22,
+			},
+			&Container{
+				ID:   "f717f795bcccd674628b92f77a72f4b80b2c6b5da289846a0edbd21fb4c462db",
+				Name: "/naughty_heisenberg",
+				Port: 9000,
+			},
+		},
+	)
+
+	registry.Synchronize()
+
+	serviceRepository.AssertExpectations(t)
+	containerRepository.AssertExpectations(t)
+}
+
+func TestSynchronieWhenAllServicesWereRegisteredBefore(t *testing.T) {
+	serviceRepository := new(MockServiceRepository)
+	containerRepository := new(MockContainerRepository)
+	registry := NewRegistry(containerRepository, serviceRepository)
+
+	serviceRepository.On("GetAllIds").Return([]string{
+		"bd1d34c0ebeeb62dfdcc57327aca15d2ef3cbc39a60e44aecb7085a8d1f89fd9",
+		"f717f795bcccd674628b92f77a72f4b80b2c6b5da289846a0edbd21fb4c462db",
+	})
+	containerRepository.AssertNotCalled(t, "Register")
+
+	containerRepository.On("GetAll").Return(
+		[]*Container{
+			&Container{
+				ID:   "bd1d34c0ebeeb62dfdcc57327aca15d2ef3cbc39a60e44aecb7085a8d1f89fd9",
+				Name: "/elated_kirch",
+				Port: 22,
+			},
+			&Container{
+				ID:   "f717f795bcccd674628b92f77a72f4b80b2c6b5da289846a0edbd21fb4c462db",
+				Name: "/naughty_heisenberg",
+				Port: 9000,
+			},
+		},
+	)
+
+	registry.Synchronize()
+
+	serviceRepository.AssertExpectations(t)
+	containerRepository.AssertExpectations(t)
+}
+
+func TestSynchronieWhenOneServiceIsMissingAndOneIsRedundant(t *testing.T) {
+	serviceRepository := new(MockServiceRepository)
+	containerRepository := new(MockContainerRepository)
+	registry := NewRegistry(containerRepository, serviceRepository)
+
+	serviceRepository.On("GetAllIds").Return([]string{
+		"bd1d34c0ebeeb62dfdcc57327aca15d2ef3cbc39a60e44aecb7085a8d1f89fd9",
+		"0g1d34c0ebeeb62dfdcc57327aca15d2ef3cbc39a60e44aecb7085a8d1f89fd9",
+	})
+	containerRepository.AssertNotCalled(t, "Register")
+
+	containerRepository.On("GetAll").Return(
+		[]*Container{
+			&Container{
+				ID:   "bd1d34c0ebeeb62dfdcc57327aca15d2ef3cbc39a60e44aecb7085a8d1f89fd9",
+				Name: "/elated_kirch",
+				Port: 22,
+			},
+			&Container{
+				ID:   "f717f795bcccd674628b92f77a72f4b80b2c6b5da289846a0edbd21fb4c462db",
+				Name: "/naughty_heisenberg",
+				Port: 9000,
+			},
+		},
+	)
+
+	serviceRepository.On("Register", &Service{
+		ID:      "f717f795bcccd674628b92f77a72f4b80b2c6b5da289846a0edbd21fb4c462db",
+		Service: "/naughty_heisenberg",
+		Port:    9000,
+	}).Return(nil)
+	serviceRepository.On("Unregister", "0g1d34c0ebeeb62dfdcc57327aca15d2ef3cbc39a60e44aecb7085a8d1f89fd9").Return(nil)
+
+	registry.Synchronize()
+
+	serviceRepository.AssertExpectations(t)
+	containerRepository.AssertExpectations(t)
+}
+
+type MockServiceRepository struct {
+	mock.Mock
+}
+
+type MockContainerRepository struct {
+	mock.Mock
+}
+
+func (msr *MockServiceRepository) GetAllIds() []string {
+	args := msr.Called()
+	return args.Get(0).([]string)
+
+}
+func (msr *MockServiceRepository) Register(service *Service) error {
+	args := msr.Called(service)
+	return args.Error(0)
+}
+
+func (msr *MockServiceRepository) Unregister(serviceID string) error {
+	args := msr.Called(serviceID)
+	return args.Error(0)
+}
+
+func (mcr *MockContainerRepository) GetAll() []*Container {
+	args := mcr.Called()
+	return args.Get(0).([]*Container)
+}

--- a/registry/repositories.go
+++ b/registry/repositories.go
@@ -1,0 +1,38 @@
+package registry
+
+// ContainerRepository is responsible for keeping Containers
+type ContainerRepository interface {
+	GetAll() []*Container
+}
+
+// ServiceRepository is responsible for keeping Services
+type ServiceRepository interface {
+	GetAllIds() []string
+	Register(service *Service) error
+	Unregister(serviceID string) error
+}
+
+// Container entity
+type Container struct {
+	ID   string
+	Name string
+	Port int
+}
+
+// Service entity
+type Service struct {
+	ID      string
+	Service string
+	Tags    []string
+	Address string
+	Port    int
+	Check   ServiceCheck
+}
+
+// ServiceCheck describes details of service health check
+type ServiceCheck struct {
+	Script   string
+	HTTP     string
+	Interval string
+	TTL      string
+}


### PR DESCRIPTION
@alaa @waterlink could you take a look at this `registry` package?

I think that this solution offers best decoupling of packages:
- Completely decouples docker adapter and consul adapter from each other
- Also decouples `Registry` from docker and consul - thanks that we'll be able to easily replace this tools without changing `Synchronize` implementation and also easily add new features like passing environment variables from `ContainerRepository` to `ServiceRepository`

If this proposal is ok for you we'll just have to adjust `docker.Adapter` to implement `ContainerRepository` and adjust `consul.Adapter` to implement `ServiceRepository`
