### PR TITLE
Docker container repository

### DIFF
--- a/docker/docker.go
+++ b/docker/docker.go
@@ -1,147 +1,73 @@
 package docker
 
 import (
+	"github.com/alaa/pencil-go/registry"
 	docker "github.com/fsouza/go-dockerclient"
-	"strings"
-	"time"
 )
 
-const (
-	Endpoint = "unix:///var/run/docker.sock"
-	Interval = 5 * time.Second
-)
-
-const SRV_NAME = "SRV_NAME"
-
-type DockerClient interface {
+type dockerClient interface {
 	ListContainers(opts docker.ListContainersOptions) ([]docker.APIContainers, error)
 	InspectContainer(id string) (*docker.Container, error)
 }
 
-type TCPPorts []string
-
-type UDPPorts []string
-
-type ContainerInfo struct {
-	ID          string
-	Name        string
-	ImageID     string
-	ImageName   string
-	ServiceName string
-	Env         map[string]string
-	Created     time.Time
-	Config      *docker.Config
-	TCPPorts    TCPPorts
-	UDPPorts    UDPPorts
+// ContainerRepository is docker-based implementation of registry.ContainerRepository
+type ContainerRepository struct {
+	dockerClient dockerClient
 }
 
-type EnvVariables map[string]string
-
-type DockerAdapter struct {
-	dockerClient DockerClient
+// NewContainerRepository creates new instance of ContainerRepository structure
+func NewContainerRepository(dockerClient dockerClient) *ContainerRepository {
+	return &ContainerRepository{dockerClient: dockerClient}
 }
 
-func NewDockerAdapter(dockerClient DockerClient) *DockerAdapter {
-	return &DockerAdapter{dockerClient: dockerClient}
-}
-
-// GetRunningContainers finds running containers and returns specific details.
-// TOOD package should return error, logging should be disabled.
-func (d *DockerAdapter) GetRunningContainers() ([]ContainerInfo, error) {
-	containersIDs, err := d.getContainersIDs()
+// GetAll returns list of all running docker containers
+func (cr *ContainerRepository) GetAll() []registry.Container {
+	containersIDs, err := cr.getContainersIDs()
 	if err != nil {
-		return []ContainerInfo{}, err
+		return []registry.Container{}
 	}
-	containersDetails, err := d.getContainersDetails(containersIDs)
+	containers, err := cr.getContainers(containersIDs)
 	if err != nil {
-		return []ContainerInfo{}, err
+		return []registry.Container{}
 	}
-	return containersDetails, nil
+	return containers
 }
 
-func buildContainerInfo(container *docker.Container) ContainerInfo {
-	tcpPorts, udpPorts := getExposedPorts(container)
-	imageName := getImageName(container.Config.Image)
-	envVars := getEnvVariables(container.Config.Env)
-	srvName := serviceName(container)
-
-	return ContainerInfo{
-		ID:          container.ID,
-		Name:        container.Name,
-		ImageID:     container.Image,
-		ImageName:   imageName,
-		ServiceName: srvName,
-		Env:         envVars,
-		Created:     container.Created,
-		Config:      container.Config,
-		TCPPorts:    tcpPorts,
-		UDPPorts:    udpPorts,
+func (cr *ContainerRepository) getContainersIDs() ([]string, error) {
+	containersIDs := []string{}
+	containers, err := cr.dockerClient.ListContainers(docker.ListContainersOptions{})
+	if err != nil {
+		return []string{}, err
 	}
-}
-
-func getImageName(image string) string {
-	if img := strings.Split(image, "/"); len(img) > 1 {
-		return img[1]
-	} else {
-		return img[0]
-	}
-}
-
-func serviceName(container *docker.Container) string {
-	serviceName := getImageName(container.Config.Image)
-	serviceEnv := getEnvVariables(container.Config.Env)
-
-	if value, exsists := serviceEnv[SRV_NAME]; exsists {
-		serviceName = value
-	}
-	return serviceName
-}
-
-func getExposedPorts(container *docker.Container) (TCPPorts, UDPPorts) {
-	tcp_list := TCPPorts{}
-	udp_list := UDPPorts{}
-	exposed_ports := container.Config.ExposedPorts
-
-	for port, _ := range exposed_ports {
-		if port.Proto() == "tcp" {
-			tcp_list = append(tcp_list, port.Port())
-		} else if port.Proto() == "udp" {
-			udp_list = append(udp_list, port.Port())
-		}
-	}
-	return tcp_list, udp_list
-}
-
-func getEnvVariables(env []string) EnvVariables {
-	m := make(map[string]string)
-	for _, value := range env {
-		e := strings.Split(value, "=")
-		m[e[0]] = e[1]
-	}
-	return m
-}
-
-func (d *DockerAdapter) getContainersIDs() ([]docker.APIContainers, error) {
-	options := docker.ListContainersOptions{}
-	return d.dockerClient.ListContainers(options)
-}
-
-func (d *DockerAdapter) getContainersDetails(containers []docker.APIContainers) ([]ContainerInfo, error) {
-	list := []ContainerInfo{}
 	for _, container := range containers {
-		i, err := d.inspectContainer(container.ID)
-		if err != nil {
-			return []ContainerInfo{}, err
-		}
-		list = append(list, i)
+		containersIDs = append(containersIDs, container.ID)
 	}
-	return list, nil
+	return containersIDs, nil
 }
 
-func (d *DockerAdapter) inspectContainer(cid string) (ContainerInfo, error) {
-	data, err := d.dockerClient.InspectContainer(cid)
-	if err != nil {
-		return ContainerInfo{}, err
+func (cr *ContainerRepository) getContainers(containersIDs []string) ([]registry.Container, error) {
+	containers := []registry.Container{}
+	for _, containerID := range containersIDs {
+		containerDetails, err := cr.dockerClient.InspectContainer(containerID)
+		if err != nil {
+			return []registry.Container{}, err
+		}
+		containers = append(containers, buildContainers(containerDetails)...)
 	}
-	return buildContainerInfo(data), nil
+	return containers, nil
+}
+
+func buildContainers(container *docker.Container) []registry.Container {
+	containerWrapper := dockerContainerWrapper{*container}
+	containers := []registry.Container{}
+
+	for _, port := range containerWrapper.getExposedTCPPorts() {
+		container := registry.Container{
+			ID:   containerWrapper.ID,
+			Name: containerWrapper.getName(),
+			Port: port,
+		}
+		containers = append(containers, container)
+	}
+	return containers
 }

--- a/docker/docker_container_wrapper.go
+++ b/docker/docker_container_wrapper.go
@@ -1,0 +1,47 @@
+package docker
+
+import (
+	docker "github.com/fsouza/go-dockerclient"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type dockerContainerWrapper struct {
+	docker.Container
+}
+
+func (c *dockerContainerWrapper) getExposedTCPPorts() (ports []int) {
+	for port := range c.NetworkSettings.Ports {
+		if port.Proto() == "tcp" {
+			port, _ := strconv.Atoi(port.Port())
+			ports = append(ports, port)
+		}
+	}
+	sort.Ints(ports)
+	return
+}
+
+func (c *dockerContainerWrapper) getEnv() map[string]string {
+	envMap := make(map[string]string)
+	for _, value := range c.Config.Env {
+		envParts := strings.Split(value, "=")
+		envMap[envParts[0]] = envParts[1]
+	}
+	return envMap
+}
+
+func (c *dockerContainerWrapper) getName() string {
+	if name, exist := c.getEnv()["SRV_NAME"]; exist {
+		return name
+	}
+	return c.getImage()
+}
+
+func (c *dockerContainerWrapper) getImage() string {
+	imageParts := strings.Split(c.Config.Image, "/")
+	if len(imageParts) > 1 {
+		return imageParts[1]
+	}
+	return imageParts[0]
+}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -20,7 +20,7 @@ func (r *Registry) Synchronize() {
 	runningContainers := r.containerRepository.GetAll()
 
 	r.registerServices(registeredServicesIDs, runningContainers)
-	r.unregisterServices(registeredServicesIDs, runningContainers)
+	r.deregisterServices(registeredServicesIDs, runningContainers)
 }
 
 func (r *Registry) registerServices(registeredServicesIDs []string, runningContainers []Container) {
@@ -29,9 +29,9 @@ func (r *Registry) registerServices(registeredServicesIDs []string, runningConta
 	}
 }
 
-func (r *Registry) unregisterServices(registeredServicesIDs []string, runningContainers []Container) {
-	for _, serviceID := range r.servicesIDsToUnregister(registeredServicesIDs, runningContainers) {
-		r.serviceRepository.Unregister(serviceID)
+func (r *Registry) deregisterServices(registeredServicesIDs []string, runningContainers []Container) {
+	for _, serviceID := range r.servicesIDsToDeregister(registeredServicesIDs, runningContainers) {
+		r.serviceRepository.Deregister(serviceID)
 	}
 }
 
@@ -47,7 +47,7 @@ func (r *Registry) servicesToRegister(registeredServicesIDs []string, runningCon
 }
 
 func (r *Registry) servicesIDsToDeregister(registeredServicesIDs []string, runningContainers []Container) []string {
-	servicesIdsToUnregister := []string{}
+	servicesIdsToDeregister := []string{}
 	runningContainersIDsSet := r.containersIDsMap(runningContainers)
 	for _, serviceID := range registeredServicesIDs {
 		if _, ok := runningContainersIDsSet[serviceID]; !ok {

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -23,31 +23,31 @@ func (r *Registry) Synchronize() {
 	r.unregisterServices(registeredServicesIDs, runningContainers)
 }
 
-func (r *Registry) registerServices(registeredServicesIDs []string, runningContainers []*Container) {
+func (r *Registry) registerServices(registeredServicesIDs []string, runningContainers []Container) {
 	for _, service := range r.servicesToRegister(registeredServicesIDs, runningContainers) {
 		r.serviceRepository.Register(service)
 	}
 }
 
-func (r *Registry) unregisterServices(registeredServicesIDs []string, runningContainers []*Container) {
-	for _, serviceID := range r.servicesIDsToDeregister(registeredServicesIDs, runningContainers) {
-		r.serviceRepository.Deregister(serviceID)
+func (r *Registry) unregisterServices(registeredServicesIDs []string, runningContainers []Container) {
+	for _, serviceID := range r.servicesIDsToUnregister(registeredServicesIDs, runningContainers) {
+		r.serviceRepository.Unregister(serviceID)
 	}
 }
 
-func (r *Registry) servicesToRegister(registeredServicesIDs []string, runningContainers []*Container) []*Service {
+func (r *Registry) servicesToRegister(registeredServicesIDs []string, runningContainers []Container) []*Service {
 	servicesToRegister := []*Service{}
 	registeredServicesIDsMap := r.sliceToMap(registeredServicesIDs)
 	for _, container := range runningContainers {
 		if _, ok := registeredServicesIDsMap[container.ID]; !ok {
-			servicesToRegister = append(servicesToRegister, containerToService(container))
+			servicesToRegister = append(servicesToRegister, containerToService(&container))
 		}
 	}
 	return servicesToRegister
 }
 
-func (r *Registry) servicesIDsToDeregister(registeredServicesIDs []string, runningContainers []*Container) []string {
-	servicesIdsToDeregister := []string{}
+func (r *Registry) servicesIDsToDeregister(registeredServicesIDs []string, runningContainers []Container) []string {
+	servicesIdsToUnregister := []string{}
 	runningContainersIDsSet := r.containersIDsMap(runningContainers)
 	for _, serviceID := range registeredServicesIDs {
 		if _, ok := runningContainersIDsSet[serviceID]; !ok {
@@ -69,7 +69,7 @@ func (r *Registry) sliceToMap(slice []string) map[string]bool {
 	return result
 }
 
-func (r *Registry) containersIDsMap(containers []*Container) map[string]bool {
+func (r *Registry) containersIDsMap(containers []Container) map[string]bool {
 	result := map[string]bool{}
 	for _, container := range containers {
 		result[container.ID] = true

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -23,13 +23,13 @@ func TestSynchronizeWhenNoServicesWereRegisteredBefore(t *testing.T) {
 	}).Return(nil)
 
 	containerRepository.On("GetAll").Return(
-		[]*Container{
-			&Container{
+		[]Container{
+			Container{
 				ID:   "bd1d34c0ebeeb62dfdcc57327aca15d2ef3cbc39a60e44aecb7085a8d1f89fd9",
 				Name: "/elated_kirch",
 				Port: 22,
 			},
-			&Container{
+			Container{
 				ID:   "f717f795bcccd674628b92f77a72f4b80b2c6b5da289846a0edbd21fb4c462db",
 				Name: "/naughty_heisenberg",
 				Port: 9000,
@@ -55,13 +55,13 @@ func TestSynchronieWhenAllServicesWereRegisteredBefore(t *testing.T) {
 	containerRepository.AssertNotCalled(t, "Register")
 
 	containerRepository.On("GetAll").Return(
-		[]*Container{
-			&Container{
+		[]Container{
+			Container{
 				ID:   "bd1d34c0ebeeb62dfdcc57327aca15d2ef3cbc39a60e44aecb7085a8d1f89fd9",
 				Name: "/elated_kirch",
 				Port: 22,
 			},
-			&Container{
+			Container{
 				ID:   "f717f795bcccd674628b92f77a72f4b80b2c6b5da289846a0edbd21fb4c462db",
 				Name: "/naughty_heisenberg",
 				Port: 9000,
@@ -87,13 +87,13 @@ func TestSynchronieWhenOneServiceIsMissingAndOneIsRedundant(t *testing.T) {
 	containerRepository.AssertNotCalled(t, "Register")
 
 	containerRepository.On("GetAll").Return(
-		[]*Container{
-			&Container{
+		[]Container{
+			Container{
 				ID:   "bd1d34c0ebeeb62dfdcc57327aca15d2ef3cbc39a60e44aecb7085a8d1f89fd9",
 				Name: "/elated_kirch",
 				Port: 22,
 			},
-			&Container{
+			Container{
 				ID:   "f717f795bcccd674628b92f77a72f4b80b2c6b5da289846a0edbd21fb4c462db",
 				Name: "/naughty_heisenberg",
 				Port: 9000,
@@ -137,7 +137,7 @@ func (msr *MockServiceRepository) Deregister(serviceID string) error {
 	return args.Error(0)
 }
 
-func (mcr *MockContainerRepository) GetAll() []*Container {
+func (mcr *MockContainerRepository) GetAll() []Container {
 	args := mcr.Called()
-	return args.Get(0).([]*Container)
+	return args.Get(0).([]Container)
 }

--- a/registry/repositories.go
+++ b/registry/repositories.go
@@ -2,7 +2,7 @@ package registry
 
 // ContainerRepository is responsible for keeping Containers
 type ContainerRepository interface {
-	GetAll() []*Container
+	GetAll() []Container
 }
 
 // ServiceRepository is responsible for keeping Services


### PR DESCRIPTION
- `docker.Adapter` structure was refactored to conform to `registry.ContainerRepository` interface and now it has name `docker.ContainerRepository`
- `docker.ContainerInfo` structure was removed because most of its fields were not used anyway. It was replaced by `registry.Container`
- `docker.dockerContainerWrapper` - wraps `docker.Container`. Thanks that we are able to get appropriate data from `docker.Container` easier
