### PR TITLE
Container repository error handling

### DIFF
--- a/docker/docker.go
+++ b/docker/docker.go
@@ -21,16 +21,16 @@ func NewContainerRepository(dockerClient dockerClient) *ContainerRepository {
 }
 
 // GetAll returns list of all running docker containers
-func (cr *ContainerRepository) GetAll() []registry.Container {
+func (cr *ContainerRepository) GetAll() ([]registry.Container, error) {
 	containersIDs, err := cr.getContainersIDs()
 	if err != nil {
-		return []registry.Container{}
+		return []registry.Container{}, err
 	}
 	containers, err := cr.getContainers(containersIDs)
 	if err != nil {
-		return []registry.Container{}
+		return []registry.Container{}, err
 	}
-	return containers
+	return containers, nil
 }
 
 func (cr *ContainerRepository) getContainersIDs() ([]string, error) {

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -24,11 +24,11 @@ func NewContainerRepository(dockerClient dockerClient) *ContainerRepository {
 func (cr *ContainerRepository) GetAll() ([]registry.Container, error) {
 	containersIDs, err := cr.getContainersIDs()
 	if err != nil {
-		return []registry.Container{}, err
+		return nil, err
 	}
 	containers, err := cr.getContainers(containersIDs)
 	if err != nil {
-		return []registry.Container{}, err
+		return nil, err
 	}
 	return containers, nil
 }
@@ -37,7 +37,7 @@ func (cr *ContainerRepository) getContainersIDs() ([]string, error) {
 	containersIDs := []string{}
 	containers, err := cr.dockerClient.ListContainers(docker.ListContainersOptions{})
 	if err != nil {
-		return []string{}, err
+		return nil, err
 	}
 	for _, container := range containers {
 		containersIDs = append(containersIDs, container.ID)
@@ -50,7 +50,7 @@ func (cr *ContainerRepository) getContainers(containersIDs []string) ([]registry
 	for _, containerID := range containersIDs {
 		containerDetails, err := cr.dockerClient.InspectContainer(containerID)
 		if err != nil {
-			return []registry.Container{}, err
+			return nil, err
 		}
 		containers = append(containers, buildContainers(containerDetails)...)
 	}

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/alaa/pencil-go/registry"
 	dockerclient "github.com/fsouza/go-dockerclient"
 	consulclient "github.com/hashicorp/consul/api"
+	"log"
 	"time"
 )
 
@@ -14,7 +15,10 @@ func main() {
 	fmt.Println("starting pencil ...\n")
 	registry := registry.NewRegistry(getContainerRepository(), getServiceRepository())
 	for range time.Tick(5 * time.Second) {
-		registry.Synchronize()
+		err := registry.Synchronize()
+		if err != nil {
+			log.Printf("Error occured during synchronization: %v\n", err)
+		}
 	}
 }
 

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -1,7 +1,5 @@
 package registry
 
-import log "github.com/brainly/eve-go-logger"
-
 // Registry understands how to synchronize registered Services with running Containers
 type Registry struct {
 	containerRepository ContainerRepository
@@ -17,17 +15,18 @@ func NewRegistry(containerRepository ContainerRepository, serviceRepository Serv
 }
 
 // Synchronize synchronizes registered services according to running containers
-func (r *Registry) Synchronize() {
+func (r *Registry) Synchronize() error {
 	registeredServicesIDs := r.serviceRepository.GetAllIds()
 	runningContainers, err := r.containerRepository.GetAll()
 
 	if err != nil {
-		log.Errorf("Error while fetching running containers: %+v", err)
-		return
+		return err
 	}
 
 	r.registerServices(registeredServicesIDs, runningContainers)
 	r.deregisterServices(registeredServicesIDs, runningContainers)
+
+	return nil
 }
 
 func (r *Registry) registerServices(registeredServicesIDs []string, runningContainers []Container) {

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -1,5 +1,7 @@
 package registry
 
+import log "github.com/brainly/eve-go-logger"
+
 // Registry understands how to synchronize registered Services with running Containers
 type Registry struct {
 	containerRepository ContainerRepository
@@ -17,7 +19,12 @@ func NewRegistry(containerRepository ContainerRepository, serviceRepository Serv
 // Synchronize synchronizes registered services according to running containers
 func (r *Registry) Synchronize() {
 	registeredServicesIDs := r.serviceRepository.GetAllIds()
-	runningContainers := r.containerRepository.GetAll()
+	runningContainers, err := r.containerRepository.GetAll()
+
+	if err != nil {
+		log.Errorf("Error while fetching running containers: %+v", err)
+		return
+	}
 
 	r.registerServices(registeredServicesIDs, runningContainers)
 	r.deregisterServices(registeredServicesIDs, runningContainers)

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -2,17 +2,10 @@ package registry
 
 import (
 	"errors"
-	log "github.com/brainly/eve-go-logger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"os"
 	"testing"
 )
-
-func TestMain(m *testing.M) {
-	log.SetupMock()
-	os.Exit(m.Run())
-}
 
 func TestSynchronizeWhenNoServicesWereRegisteredBefore(t *testing.T) {
 	serviceRepository := new(MockServiceRepository)
@@ -136,14 +129,12 @@ func TestLogErrorIfFetchingContainersFailed(t *testing.T) {
 		"0g1d34c0ebeeb62dfdcc57327aca15d2ef3cbc39a60e44aecb7085a8d1f89fd9",
 	})
 
-	containerRepository.On("GetAll").Return([]Container{}, errors.New("foo"))
+	expectedError := errors.New("foo")
+	containerRepository.On("GetAll").Return([]Container{}, expectedError)
 
-	logged := log.CaptureOutput(func() {
-		registry.Synchronize()
-	})
+	err := registry.Synchronize()
 
-	expectedLog := "[testing] 2006-01-02 15:04:05 [ERROR] Error while fetching running containers: foo\n"
-	assert.Equal(t, expectedLog, logged)
+	assert.Equal(t, expectedError, err)
 }
 
 type MockServiceRepository struct {

--- a/registry/repositories.go
+++ b/registry/repositories.go
@@ -2,7 +2,7 @@ package registry
 
 // ContainerRepository is responsible for keeping Containers
 type ContainerRepository interface {
-	GetAll() []Container
+	GetAll() ([]Container, error)
 }
 
 // ServiceRepository is responsible for keeping Services


### PR DESCRIPTION
This pull request is child of #6 and it may contain its commits if #6 was not merged yet.
It adds error handling for `registry.ContainerRepository`, for its usages in `registry.Registry` and for its docker-based implementation in `docker.ContainerRepository`
