### PR TITLE
Adds tags support

### DIFF
--- a/consul/consul.go
+++ b/consul/consul.go
@@ -48,5 +48,6 @@ func buildAgentServiceRegistration(service *registry.Service) *consul.AgentServi
 		ID:   service.ID,
 		Name: service.Service,
 		Port: service.Port,
+		Tags: service.Tags,
 	}
 }

--- a/consul/consul_test.go
+++ b/consul/consul_test.go
@@ -17,12 +17,14 @@ func TestThatRegisterCallConsulApiRegister(t *testing.T) {
 		ID:   "redis1",
 		Name: "redis",
 		Port: 8000,
+		Tags: []string{"tag1", "tag2"},
 	}).Return(nil)
 
 	err := consulServiceRepository.Register(&registry.Service{
 		ID:      "redis1",
 		Service: "redis",
 		Port:    8000,
+		Tags:    []string{"tag1", "tag2"},
 	})
 
 	assert.Nil(t, err)

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -65,6 +65,7 @@ func buildContainers(container *docker.Container) []registry.Container {
 		container := registry.Container{
 			ID:   containerWrapper.ID,
 			Name: containerWrapper.getName(),
+			Tags: containerWrapper.getTags(),
 			Port: port,
 		}
 		containers = append(containers, container)

--- a/docker/docker_container_wrapper.go
+++ b/docker/docker_container_wrapper.go
@@ -22,6 +22,14 @@ func (c *dockerContainerWrapper) getExposedTCPPorts() (ports []int) {
 	return
 }
 
+func (c *dockerContainerWrapper) getTags() []string {
+	tags, exist := c.Config.Labels["tags"]
+	if !exist {
+		return []string{}
+	}
+	return strings.Split(tags, ",")
+}
+
 func (c *dockerContainerWrapper) getEnv() map[string]string {
 	envMap := make(map[string]string)
 	for _, value := range c.Config.Env {

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -64,7 +64,7 @@ func (r *Registry) servicesIDsToDeregister(registeredServicesIDs []string, runni
 }
 
 func containerToService(container *Container) *Service {
-	return &Service{ID: container.ID, Service: container.Name, Port: container.Port}
+	return &Service{ID: container.ID, Service: container.Name, Port: container.Port, Tags: container.Tags}
 }
 
 func (r *Registry) sliceToMap(slice []string) map[string]bool {

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -17,11 +17,13 @@ func TestSynchronizeWhenNoServicesWereRegisteredBefore(t *testing.T) {
 		ID:      "bd1d34c0ebeeb62dfdcc57327aca15d2ef3cbc39a60e44aecb7085a8d1f89fd9",
 		Service: "/elated_kirch",
 		Port:    22,
+		Tags:    []string{},
 	}).Return(nil)
 	serviceRepository.On("Register", &Service{
 		ID:      "f717f795bcccd674628b92f77a72f4b80b2c6b5da289846a0edbd21fb4c462db",
 		Service: "/naughty_heisenberg",
 		Port:    9000,
+		Tags:    []string{"tag1", "tag2"},
 	}).Return(nil)
 
 	containerRepository.On("GetAll").Return(
@@ -30,11 +32,13 @@ func TestSynchronizeWhenNoServicesWereRegisteredBefore(t *testing.T) {
 				ID:   "bd1d34c0ebeeb62dfdcc57327aca15d2ef3cbc39a60e44aecb7085a8d1f89fd9",
 				Name: "/elated_kirch",
 				Port: 22,
+				Tags: []string{},
 			},
 			Container{
 				ID:   "f717f795bcccd674628b92f77a72f4b80b2c6b5da289846a0edbd21fb4c462db",
 				Name: "/naughty_heisenberg",
 				Port: 9000,
+				Tags: []string{"tag1", "tag2"},
 			},
 		},
 		nil,
@@ -63,11 +67,13 @@ func TestSynchronieWhenAllServicesWereRegisteredBefore(t *testing.T) {
 				ID:   "bd1d34c0ebeeb62dfdcc57327aca15d2ef3cbc39a60e44aecb7085a8d1f89fd9",
 				Name: "/elated_kirch",
 				Port: 22,
+				Tags: []string{},
 			},
 			Container{
 				ID:   "f717f795bcccd674628b92f77a72f4b80b2c6b5da289846a0edbd21fb4c462db",
 				Name: "/naughty_heisenberg",
 				Port: 9000,
+				Tags: []string{"tag1", "tag2"},
 			},
 		},
 		nil,
@@ -96,11 +102,13 @@ func TestSynchronieWhenOneServiceIsMissingAndOneIsRedundant(t *testing.T) {
 				ID:   "bd1d34c0ebeeb62dfdcc57327aca15d2ef3cbc39a60e44aecb7085a8d1f89fd9",
 				Name: "/elated_kirch",
 				Port: 22,
+				Tags: []string{},
 			},
 			Container{
 				ID:   "f717f795bcccd674628b92f77a72f4b80b2c6b5da289846a0edbd21fb4c462db",
 				Name: "/naughty_heisenberg",
 				Port: 9000,
+				Tags: []string{"tag1", "tag2"},
 			},
 		},
 		nil,
@@ -110,6 +118,7 @@ func TestSynchronieWhenOneServiceIsMissingAndOneIsRedundant(t *testing.T) {
 		ID:      "f717f795bcccd674628b92f77a72f4b80b2c6b5da289846a0edbd21fb4c462db",
 		Service: "/naughty_heisenberg",
 		Port:    9000,
+		Tags:    []string{"tag1", "tag2"},
 	}).Return(nil)
 	serviceRepository.On("Deregister", "0g1d34c0ebeeb62dfdcc57327aca15d2ef3cbc39a60e44aecb7085a8d1f89fd9").Return(nil)
 

--- a/registry/repositories.go
+++ b/registry/repositories.go
@@ -17,6 +17,7 @@ type Container struct {
 	ID   string
 	Name string
 	Port int
+	Tags []string
 }
 
 // Service entity


### PR DESCRIPTION
This pull requests adds tags support for pencil.
Docker-based implementation of ContainerRepository uses labels feature to get list of tags.

https://docs.docker.com/userguide/labels-custom-metadata/

@alaa what do you think to use this labels also for holding name of service instead of `SRV_NAME` environment variable? I think that labels are much more suitable for that than environment variable.
